### PR TITLE
updated

### DIFF
--- a/chapters/devops/puppet.md
+++ b/chapters/devops/puppet.md
@@ -1,8 +1,19 @@
-# Puppet :wave:
+# Puppet :smiley:
 
 :o: ubuntu 16.04 is outdated. Could that not be done on 18.04
 
+:white_check_mark: Installed in 18.04. Created two VM. 
+Installed Puppet Master on on VM and Puppet agent on other VM.
+Used bridged network so that both VM can communicate with each other. 
+Verified and tested successful installation.
+Installed Puppet Enterprise on Ubuntu 18.04 using both web and text mode install methods and successfully tested.
+Updated Puppet Enterprise report content based on result of successful installation. 
+Removed redundant steps from content and organized steps for Puppet Enterprise installation.
+
+
 :o: export PECONFPATH=path of pe.conf file, this would mean you need to put a $ before PECONFPATH when using it
+
+:white_check_mark: Corrected
 
 :o: review has been halted as it was verified that this was not tested
 by the contributor. We can not accept sections and chapters that are
@@ -150,9 +161,9 @@ forms.
 
 ## Install Opensource Puppet on Ubuntu
 
-We will demonstrate installation of Puppet 4 on Ubuntu 16.04
+We will demonstrate installation of Puppet on Ubuntu
 
-Prerequisite - 4 GB RAM, Ubuntu 16 04 box ( standalone or VM )
+Prerequisite - Atleast 4 GB RAM, Ubuntu box ( standalone or VM )
 
 First, we need to make sure that Puppet master and agent is able
 to communicate with each other. Agent should be able to connect
@@ -175,8 +186,9 @@ try to connect
 
 press `<ctrl> + O` to Save and `<ctrl> + X` to exit
 
-Next, we will install Puppet server. We will excute below commands to 
-pull from official Puppet Labs Repository
+Next, we will install Puppet on Ubuntu  server. 
+We will excute below commands to pull from official 
+Puppet Labs Repository
 
 ```bash
 $ curl -O https://apt.puppetlabs.com/puppetlabs-release-pc1-xenial.deb
@@ -204,13 +216,10 @@ to configure Puppet server for 3GB RAM. Note that default value
 of this parameter is 2g.
 
 ```
-               /etc/default/puppetserver
-               ---------------------------
-
 JAVA_ARGS="-Xms3g -Xmx3g -XX:MaxPermSize=256m"
 ```
 
-press <ctrl> + O to Save and <ctrl> + X to exit
+press `<ctrl> + O` to Save and `<ctrl> + X` to exit
  
 By default Puppet server is configured to use port 8140 to 
 communicate with agents. We need to make sure that firewall
@@ -397,10 +406,9 @@ Notice: Applied catalog in 0.13 seconds
 
 ## Installation of Puppet Enterprise
 
-### Download and verify installation package
 
-
-First, download `ubuntu-<version and arch>.tar.gz` on VM  
+First, download `ubuntu-<version and arch>.tar.gz` and CPG 
+signature file on Ubuntu VM  
 
 
 Second, we import Puppet public key 
@@ -409,10 +417,46 @@ Second, we import Puppet public key
 $ wget -O - https://downloads.puppetlabs.com/puppet-gpg-signing-key.pub | gpg --import
 ```
 
+we will see ouput as
+
+```
+ritesh@ritesh-pe-text:~/pe1$ wget -O 
+- https://downloads.puppetlabs.com/puppet-gpg-signing-key.pub | gpg --import
+--2019-02-03 14:02:54--  https://downloads.puppetlabs.com/puppet-gpg-signing-key.pub
+Resolving downloads.puppetlabs.com 
+(downloads.puppetlabs.com)... 2600:9000:201a:b800:10:d91b:7380:93a1
+, 2600:9000:201a:800:10:d91b:7380:93a1, 2600:9000:201a:be00:10:d91b:7380:93a1, ...
+Connecting to downloads.puppetlabs.com (downloads.puppetlabs.com)
+|2600:9000:201a:b800:10:d91b:7380:93a1|:443... connected.
+HTTP request sent, awaiting response... 200 OK
+Length: 3139 (3.1K) [binary/octet-stream]
+Saving to: ‘STDOUT’
+
+-                   100%[===================>]   3.07K  --.-KB/s    in 0s      
+
+2019-02-03 14:02:54 (618 MB/s) - written to stdout [3139/3139]
+
+gpg: key 7F438280EF8D349F: "Puppet, Inc. Release Key 
+(Puppet, Inc. Release Key) <release@puppet.com>" not changed
+gpg: Total number processed: 1
+gpg:              unchanged: 1
+```
+
 Third, we print fingerprint of used key
 
 ```bash
 $ gpg --fingerprint 0x7F438280EF8D349F
+```
+
+we will see successful output as
+
+```
+ritesh@ritesh-pe-text:~/pe1$ gpg --fingerprint 0x7F438280EF8D349F
+pub   rsa4096 2016-08-18 [SC] [expires: 2021-08-17]
+      6F6B 1550 9CF8 E59E 6E46  9F32 7F43 8280 EF8D 349F
+uid           [ unknown] Puppet, Inc. Release Key 
+(Puppet, Inc. Release Key) <release@puppet.com>
+sub   rsa4096 2016-08-18 [E] [expires: 2021-08-17]
 ```
 
 Fourth, we verify release signature of installed package
@@ -421,9 +465,190 @@ Fourth, we verify release signature of installed package
 $ gpg --verify puppet-enterprise-VERSION-PLATFORM.tar.gz.asc
 ```
 
+successful output will show as
 
-### Text mode monolithic installation
+```
+ritesh@ritesh-pe-text:~/pe$ gpg --verify 
+puppet-enterprise-2019.0.2-ubuntu-18.04-amd64.tar.gz.asc
+gpg: assuming signed data in 'puppet-enterprise-2019.0.2-ubuntu-18.04-amd64.tar.gz'
+gpg: Signature made Fri 25 Jan 2019 02:03:23 PM EST
+gpg:                using RSA key 7F438280EF8D349F
+gpg: Good signature from "Puppet, Inc. Release Key 
+(Puppet, Inc. Release Key) <release@puppet.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 6F6B 1550 9CF8 E59E 6E46  9F32 7F43 8280 EF8D 349
+```
 
+Next, we need to unpack installation tarball.
+Store location of path in `$TARBALL` variable. This  variable will be
+used in our installation.
+
+```bash
+$ export TARBALL=path of tarball file
+```
+
+then, we extract tarball
+
+```bash
+$ tar -xf $TARBALL
+```
+
+Next, we run installer from installer directory
+
+```bash
+$ sudo ./puppet-enterprise-installer
+```
+
+This will ask us to chose installation option; we could chose from
+guided installation or text based installation
+
+```
+ritesh@ritesh-ubuntu-pe:~/pe/puppet-enterprise-2019.0.2-ubuntu-18.04-amd64
+$ sudo ./puppet-enterprise-installer
+~/pe/puppet-enterprise-2019.0.2-ubuntu-18.04-amd64 
+~/pe/puppet-enterprise-2019.0.2-ubuntu-18.04-amd64
+=============================================================
+    Puppet Enterprise Installer
+=============================================================
+
+## Installer analytics are enabled by default.
+## To disable, set the DISABLE_ANALYTICS environment variable and rerun 
+this script. 
+For example, "sudo DISABLE_ANALYTICS=1 ./puppet-enterprise-installer".
+## If puppet_enterprise::send_analytics_data is set to false in your 
+existing pe.conf, this is not necessary and analytics will be disabled.
+
+Puppet Enterprise offers three different methods of installation.
+
+[1] Express Installation (Recommended)
+
+This method will install PE and provide you with a link at the end 
+of the installation to reset your PE console admin password
+
+Make sure to click on the link and reset your password before proceeding 
+to use PE
+
+[2] Text-mode Install
+
+This method will open your EDITOR (vi) with a PE config file (pe.conf) 
+for you to edit before you proceed with installation.
+
+The pe.conf file is a HOCON formatted file that declares parameters 
+and values needed to install and configure PE.
+We recommend that you review it carefully before proceeding.
+
+[3] Graphical-mode Install
+
+This method will install and configure a temporary webserver to walk 
+you through the various configuration options.
+
+NOTE: This method requires you to be able to access port 3000 on this 
+machine from your desktop web browser.
+
+=============================================================
+
+ How to proceed? [1]: 
+
+-------------------------------------------------------------------
+```
+
+Press 3 for web based Graphic-mode-Install
+
+when successfull, we will see output as
+
+```
+## We're preparing the Web Installer...
+
+2019-02-02T20:01:39.677-05:00 Running command: 
+mkdir -p /opt/puppetlabs/puppet/share/installer/installer
+2019-02-02T20:01:39.685-05:00 Running command: 
+cp -pR /home/ritesh/pe/puppet-enterprise-2019.0.2-ubuntu-18.04-amd64/* 
+/opt/puppetlabs/puppet/share/installer/installer/
+
+## Go to https://ritesh-ubuntu-pe:3000 in your browser to continue installation.
+
+```
+
+By default Puppet Enterprise server uses 3000 port. Make sure that 
+firewall allows communication on port 3000
+
+```bash
+$ sudo ufw allow 3000
+```
+
+Next, go to `https://localhost:3000` url for completing installation
+
+Click on `get started` button.
+
+Chose install on this server
+
+Enter `<mypserver>` as DNS name. This is our Puppet Server name.
+This can be configured in confile file also.
+
+Enter console admin password
+
+Click continue 
+
+we will get confirm the plan screen with following information
+
+```
+The Puppet master component
+Hostname 
+ritesh-ubuntu-pe
+DNS aliases
+<mypserver>
+```
+click continue and verify installer validation screen.
+
+click `Deploy Now` button
+
+Puppet enterprise will be installed and will display message
+on screen 
+
+```
+Puppet agent ran sucessfully
+```
+
+login to console with admin password that was set earlier
+and click on nodes links to manage nodes.
+
+
+Installing Puppet Enterprise as Text mode monolithic installation
+
+```bash
+$ sudo ./puppet-enterprise-installer
+```
+
+Enter 2 on `How to Proceed` for text mode  monolithic installation.
+Following message will be displayed if successfull.
+
+```
+2019-02-02T22:08:12.662-05:00 - [Notice]: Applied catalog in 339.28 seconds
+2019-02-02T22:08:13.856-05:00 - [Notice]: 
+Sent analytics: pe_installer - install_finish - succeeded
+* /opt/puppetlabs/puppet/bin/puppet infrastructure configure  
+--detailed-exitcodes --environmentpath /opt/puppetlabs/server/data/environments 
+--environment enterprise --no-noop --install=2019.0.2 --install-method='repair'  
+* returned: 2
+
+## Puppet Enterprise configuration complete!
+
+
+Documentation: https://puppet.com/docs/pe/2019.0/pe_user_guide.html
+Release notes: https://puppet.com/docs/pe/2019.0/pe_release_notes.html
+
+If this is a monolithic configuration, run 'puppet agent -t' to complete the 
+setup of this system.
+
+If this is a split configuration, install or upgrade the remaining PE components, 
+and then run puppet agent -t on the Puppet master, PuppetDB, and PE console, 
+in that order.
+~/pe/puppet-enterprise-2019.0.2-ubuntu-18.04-amd64
+2019-02-02T22:08:14.805-05:00 Running command: /opt/puppetlabs/puppet/bin/puppet 
+agent --enable
+ritesh@ritesh-pe-text:~/pe/puppet-enterprise-2019.0.2-ubuntu-18.04-amd64$
+```
 
 This is called as monolithic installation as all components of 
 Puppet Enterprise such as Puppet master, PuppetDB and Console are 
@@ -435,9 +660,9 @@ network grows. This is recommended installation type for small to
 mid size organizations [@hid-sp18-523-mono].
 
 
-`pe.conf` configuration file needs to be specified in order to install
-Puppet Enterprise in text mode. This file contains parameters and
-values for installing, upgrading and configuring Puppet.
+`pe.conf` configuration file will be opened in editor to configure
+values. This file contains parameters and values for installing, 
+upgrading and configuring Puppet.
 
 Some important parameters that can be specified in 
 `pe.conf` file are
@@ -450,45 +675,14 @@ puppet_enterprise::puppetdb_database_name
 puppet_enterprise::puppetdb_database_user
 ```
 
-First, we need to unpack installation tarball.
-Store location of path in `$TARBALL` variable. This  variable will be
-used in our installation.
+Lastly, we run puppet after installation is complete
 
 ```bash
-$ export TARBALL=path of tarball file
-```
-
-Second, we extract tarball
-
-```bash
-$ tar -xf $TARBALL
-```
-
-Third, we define variable for storing path of configuration file 
-
-```bash
-$ export PECONFPATH=path of pe.conf file
-```
-
-Fourth, we specify console admin password in `pe.conf` file
-and use default certificate
-
-Fifth, we run installer from installer directory
-
-```bash
-$ sudo ./puppet-enterprise-installer -c PECONFPATH
+$ puppet agent -t 
 ```
 
 
-Lastly, we run puppet twice after installation is complete
-
-```bash
-$ puppet agent `-t` 
-```
-
-
-### Text mode split installation
-
+Text mode split installation is performed for large networks.
 Compared to monolithic installation split installation type
 can manage large infrastucture that requires more than 20,000
 nodes.  In this type of installation different components of 
@@ -499,112 +693,11 @@ organizations with large infrastructure needs [@hid-sp18-523-split].
 In this type of installation, we need to install componenets in 
 specific order. First master then puppet db followed by console.
 
-#### Install Puppet master
 
-First, we unpack installation tarball
-
-```bash
-$ tar -xf <TARBALL_FILENAME>
-```
-
-Second, we run installer from installed directory. 
-we run it with  `-c` flag pointed to 
-`pe.conf` if parameters have already been populated.
-
-
-```bash
-$ sudo ./puppet-enterprise-installer -c PECONFPATH
-```
-
-if parameters values are not already defined in `peconf`
-file, we run command without `-c` flag
-
-```bash
-$ sudo ./puppet-enterprise-installer
-```
-
-Third, we select text-mode when prompted. `pe.conf` file will be opened.
-
-Fourth, we change master node related configuration parameters such as
-host name
-
-Installation will begin after file is saved and closed.
-
-When installation is completed, transfer installer and pe.conf file 
-located at `PECONFPATH` to next server if we need to set up
-infrastructure with multiple puppet masters.
-
-#### Install PuppetDB
-
-PuppetDB stores details of relations, nodes and resources
-of whole infrastructure.
-
-we need to install PuppetDB after successful installation of
-master.
-
-First, we unpack installation tarball
-
-```bash
-$ tar -xf <TARBALL_FILENAME>
-```
-
-Second, we run installer from installation directory
-
-```bash
-$ sudo ./puppet-enterprise-installer -c <FULL PATH TO pe.conf>
-```
-
-Third, we select text-mode when prompted. `pe.conf` file will be opened
-
-
-Fourth, we edit value of `puppet_enterprise::puppet_master_host` 
-parameter to puppet master host name and change other database
-related configuration parameter values
-
-Installation will begin after file is saved and closed.
-
-Transfer installer and `pe.conf` file to next puppet db server 
-in case if infrastructure with multiple PuppetDB server needs to be set up.
-
-
-#### Install the console
-
-Console is installed after installing master and PuppetDB.
-
-First, we unpack installation tarball
-
-```bash
-$ tar -xf <TARBALL_FILENAME>
-```
-
-Second, we run installer from installation directory
-
-```bash
-$ sudo ./puppet-enterprise-installer -c <FULL PATH TO pe.conf>
-```
-
-Third, we select text-mode when prompted. `pe.conf` file will be opened
-
-Fourth, we edit value of `puppet_enterprise::puppet_master_host` 
-parameter to puppet master host name
-
-Installation will begin after file is saved and closed.
-
-#### Run Puppet on infrastructure nodes
-
-To complete split installation, run Puppet on all infrastructure 
-nodes in same order as they were installed.
-
-* Run Puppet on master node.
-* Run Puppet on PuppetDB node.
-* Run Puppet on master node a second time.
-* Run Puppet on console node.
-
-## Configuring Puppet
-
-`puppet.conf` is main puppet configuration file. Most configuration settings 
-of Puppet Enterprise componenets such as Master, Agent and security certificates 
-are all specified in this file.
+Puppet Enterprise master and agent settings can be configured in
+`puppet.conf` file. Most configuration settings of Puppet Enterprise 
+componenets such as Master, Agent and  security certificates are all 
+specified in this file.
 
 Config section of Agent Node
 
@@ -612,7 +705,7 @@ Config section of Agent Node
 ```bash
 [main]
 
-certname = <http://testing.hid520-hid523.com/>
+certname = <http://your-domain-name.com/>
 server = puppetserver
 environment = testing
 runinterval = 4h
@@ -624,8 +717,8 @@ Config section of Master Node
 ```bash
 [main]
 
-certname =  <http://testing.hid520-hid523.com/>
-server = puppetmaster
+certname =  <http://your-domain-name.com/>
+server = puppetserver
 environment = testing
 runinterval = 4h
 strict_variables = true
@@ -635,7 +728,7 @@ strict_variables = true
 ```bash
 [master]
 
-dns_alt_names = puppetserver,puppet, <http://puppet.test.com/>
+dns_alt_names = puppetserver,puppet, <http://your-domain-name.com/>
 reports = pupated
 storeconfigs_backend = puppetdb
 storeconfigs = true
@@ -644,195 +737,8 @@ environment_timeout = unlimited
 
 Comment lines, Settings lines and Settings variables are main
 components of puppet configuration file. Comments in config files 
-are specified by prefixing hash character.Setting line consists 
+are specified by prefixing hash character. Setting line consists 
 name of setting followed by equal sign, value of setting are specified 
 in this section. Setting variable value generally consists of one word 
 but multiple can be specified in rare cases [@hid-sp18-523-config].
-
-## Setting up Puppet master
-
-Puppet server software is installed on puppet master node which then
-pushes configuration to clients nodes (puppet agents).
-
-Pull software package from repository.
-
-```bash
-$ sudo rpm -ivh 
-https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-```
-
-Install puppetserver package on master node
-
-```bash
-$ sudo yum -y install puppetserver
-```
-
-By default 2GM memory is allocated, but it can be configured based on
-available memory as well as number of puppet agent nodes.  
-
-Open configuration file to change configured value
-
-```bash
-$ sudo vi /etc/sysconfig/puppetserver
-```
-
-For example set value of variable to increase memory to 3GB
-by adding 3g after -Xmx to `JAVA_ARGS`. 
-
-```bash
-JAVA_ARGS="-Xms3g -Xmx3g"
-```
-
-Start puppet server 
-
-```bash
-$ sudo systemctl start puppetserver
-```
-
-Start puppet server after master server is started.
-
-```bash
-$ sudo systemctl enable puppetserver
-```
-
-## Installing puppet agent
-
-
-Puppet agent is installed on all nodes that needs to be part of 
-managed network. Puppet master can not reach and manage any node 
-that does  not have puppet agent installed.  
-Puppet agent can be installed and run on any Linux, Unix or 
-windows based platforms[@hid-sp18-523-agent].
-
-
-First, we need to connect to puppet repository
-
-```bash
-$ sudo rpm -ivh 
-https://yum.puppetlabs.com/puppetlabs-release-pc1-el-7.noarch.rpm
-```
-
-Second, we need to install Puppet agent
-
-```bash
-$ sudo yum -y install puppet-agent
-```
-
-Third, we need to enable agent
-
-```bash
-$ sudo /opt/puppetlabs/bin/puppet resource service puppet ensure=running enable=true
-```
- 
-Once puppet agent is installed and runs for first time, it
-generates a SSL certificate and sends it to the master for
-signing. Puppet master communicates and manages client nodes after 
-certificate is signed.
-
-Each puppet client node that needs to be managed with puppet
-is required to follow this process[@hid-sp18-523-agent].
-
-First, we want to view all requests on master
-
-
-```bash $ sudo /opt/puppetlabs/bin/puppet cert list --all ```
-
-cryptographic hash value of agent node will be displayed
-
-```bash
-
-+ "host1.hid523.example.com" (SHA256) F5:DC:68:24:63:E6:F1:9E:C5:
-FE:F5:1A:90:93:DF:19:F2:28:8B:D7:BD:D2:6A:83:07:BA:FE:24:11:24:54:6A
-
-"host2.hid523.example.com" (SHA256) F5:DC:68:24:63:E6:F1:9E:C5:
-FE:F5:1A:90:93:DF:19:F2:28:8B:D7:BD:D2:6A:83:07:BA:FE:24:11:24:54:6A
-
-```
-
-output staring with + are signed request where as lines that 
-does not begin with + sign are unsigned request.
-
-
-Second, we we need to sign unsigned request
-
-
-```bash
-$ sudo /opt/puppetlabs/bin/puppet cert sign host2.hid523.example.com
-```
-
-Puppet master is now ready to communicate and manage client nodes
-
-
-Lastly, we can remove specific agent node from puppet infrastructure
-for debugging or investigation.
-
-```bash
-$ sudo /opt/puppetlabs/bin/puppet cert clean hostname
-```
-
-
-# Managing puppet environment through tool
-
-r10k is pupper environment management tool that is used for managing 
-configurations related to different environments such as testing, staging 
-and production. Configuration information is stored in central repository. 
-r10k tool creates an environment on puppet master and then uses modules 
-stored in repo to install and update the environment[@hid-sp18-523-r10k]. 
-
-Install r10k tool 
-
-```bash
-$ urlgrabber -o /etc/yum.repos.d/timhughes-r10k-epel-6.repo 
-[https://copr.fedoraproject.org/coprs/timhughes/yum]
-(https://copr.fedoraproject.org/coprs/timhughes/yum)
--y install rubygem-r10k
-```
-
-Configure environment in /etc/puppet/puppet.conf for r10k
-
-```bash
-[main]
-environmentpath = $confdir/environments
-```
-
-### Create configuration file for r10k config
-
-```bash 
-$ cat <<EOF >/etc/r10k.yaml
-:cachedir: '/var/cache/r10k'
-:sources:
-:opstree:
-remote: '/var/lib/git/fullstackpuppet-
-environment.git'
-basedir: '/etc/puppet/environments'
-EOF
-```
-
-### Installing Puppet manifest and module
-
-```bash
-$ r10k deploy environment -pv
-```
-
-Creating cron job is recommended as environment needs to be updated
-frequently.
-
-```bash
-$ cat << EOF > /etc/cron.d/r10k.conf SHELL=/bin/bash 
-PATH=/sbin:/bin:/usr/sbin:/usr/bin H/15 
-* * * * root r10k deploy environment -p EOF
-```
-
-### Testing installation
-
-Puppet manifest for Puppet module needs to be compiled in order to
-test and validate if environment is working correctly.  
-
-Get YAML manifest for puppet environment
-
-```bash
-$ curl --cert /etc/puppet/ssl/certs/puppet.corp.guest.pem \
---key /etc/puppet/ssl/private_keys/puppet.corp.guest.pem \
---cacert /etc/puppet/ssl/ca/ca_crt.pem \-H 'Accept: yaml' \
-```
 


### PR DESCRIPTION
Installed in 18.04. Created two VM. 
Installed Puppet Master on on VM and Puppet agent on other VM.
Used bridged network so that both VM can communicate with each other. 
Verified and tested successful installation.
Installed Puppet Enterprise on Ubuntu 18.04 using both web and text mode install methods and successfully tested.
Updated Puppet Enterprise report content based on result of successful installation. 
Removed redundant steps from content and organized steps for Puppet Enterprise installation.