### PR TITLE
Updated dead link and corrected symbol.

### DIFF
--- a/chapters/preface/corrections.md
+++ b/chapters/preface/corrections.md
@@ -8,7 +8,7 @@ In case you see an error or like to make a contribution of your own
 section or chapter, you can do so in GitHub via pull requests.
 
 The easiest way to fix an error is to read the ePub and click on the
-cloud symbol (![Cloud icon](images/cloud.png)) in a heading where you see the error. This will
+cloud symbol (:cloud:) in a heading where you see the error. This will
 bring you to an editable document in GitHub. You can directly fix
 the error in the web browser and create there a pull request.
 Naturally, you need to be signed into GitHub before you can edit and

--- a/chapters/preface/corrections.md
+++ b/chapters/preface/corrections.md
@@ -2,13 +2,13 @@
 
 The material collected in this document is managed in
 
-* <https://github.com/cloudmesh-community/book/chapters>
+* <https://github.com/cloudmesh-community/book/tree/master/chapters>
 
 In case you see an error or like to make a contribution of your own
 section or chapter, you can do so in GitHub via pull requests.
 
 The easiest way to fix an error is to read the ePub and click on the
-cloud ![Github](images/github.png) symbol in a heading where you see the error. This will
+cloud symbol (![Cloud icon](images/cloud.png)) in a heading where you see the error. This will
 bring you to an editable document in GitHub. You can directly fix
 the error in the web browser and create there a pull request.
 Naturally, you need to be signed into GitHub before you can edit and


### PR DESCRIPTION
The main link in this section to GitHub was leading to a 404.  This PR updated it to where I believe it was meant to go.  This PR also swapped the GitHub symbol with the Cloud symbol for clarity since it was the topic of the sentence and not GitHub.