### PR TITLE
Added find command examples

### DIFF
--- a/chapters/cloud/multipass.md
+++ b/chapters/cloud/multipass.md
@@ -130,11 +130,19 @@ Make sure they are purged
 $ multipass list --format yaml
 ```
 
-Find other images
+`multipass find` can be used to find other available images.
 
-```bash
-$ multipass find
-```
+For full details see the [find command docs](https://multipass.run/docs/find-command)
+
+**Examples**
+
+| Find Command      | Description |
+| ----------------- | ------------------------------------- | 
+| `multipass find`  | Find other images |
+| `multipass find default` | Find the default image |
+| `multipass find lts` | Find the current LTS image |
+| `multipass find bionic` | Find the Bionic Beaver image |
+
 
 To switch to a different VM support you can use
 


### PR DESCRIPTION
This commit adds some find command examples and a link to the full doc.

I didn't find any images available on my OS (OS X and Ubuntu) that were not already in the doc.