### PR TITLE
A comma is missing in line 59

### DIFF
--- a/chapters/prg/python/cloudmesh/dict.md
+++ b/chapters/prg/python/cloudmesh/dict.md
@@ -56,7 +56,7 @@ contain dicts within dicts. For this we can use `FlatDict`.
 from cloudmesh.common.Flatdict import FlatDict
 
 data = {
-    "name": "Gregor"
+    "name": "Gregor",
     "address": {
         "city": "Bloomington",
         "state": "IN"


### PR DESCRIPTION
In flatdict example, a comma is missing.